### PR TITLE
DbReplace: Fix Link to Result Page

### DIFF
--- a/ManipulatorModules/DbReplace/DbReplace.cshtml
+++ b/ManipulatorModules/DbReplace/DbReplace.cshtml
@@ -9,7 +9,7 @@
         </div>
     </fieldset>
     <h2 class="dnnFormSectionHead"><a href="#">Load Json</a></h2>
-    <fieldset class="ddnClear">
+    <fieldset class="dnnClear">
         <div class="dnnFormItem">
             <label class="dnnLabel">JSON to load</label>
             <textarea type="text" name="LoadJson" style="height:200px;width:500px;" class="dnnFormInput"></textarea>

--- a/ManipulatorModules/DbReplace/DbReplaceController.cs
+++ b/ManipulatorModules/DbReplace/DbReplaceController.cs
@@ -173,7 +173,7 @@ namespace FortyFingers.DnnMassManipulate.Services
                                 {
                                     sNewText = sNewText.Replace("[*]", "<br />");
 
-                                    sOut.AppendLine(string.Format("<h4>Module: <a href=\"{3}/Default.aspx?Tabid={0}&articleType=ArticleView&articleId={1}\" target=\"_blank\">{2}</a></h4><pre>{4}</pre>", oMod.TabId, oMod.DetailId, oMod.Title, sPortal, sNewText));
+                                    sOut.AppendLine(string.Format("<h4>Module: <a href=\"{3}/Default.aspx?Tabid={0}#{1}\" target=\"_blank\">{2}</a></h4><pre>{4}</pre>", oMod.TabId, oMod.ModuleId, oMod.Title, sPortal, sNewText));
 
                                     iReplaced += 1;
                                 }
@@ -183,7 +183,7 @@ namespace FortyFingers.DnnMassManipulate.Services
 
                         case ModuleReplaceMode.ReplaceTest:
                             {
-                                sOut.AppendLine(string.Format("<div><h4>Module: <a href=\"{3}/Default.aspx?Tabid={0}&articleType=ArticleView&articleId={1}\" target=\"_blank\">{2}</a></h4><pre>{4}</pre><pre class=\"New\">{5}</pre></div><hr />", oMod.TabId, oMod.DetailId, oMod.Title, sPortal, oMod.Text, sNewText));
+                                sOut.AppendLine(string.Format("<div><h4>Module: <a href=\"{3}/Default.aspx?Tabid={0}#{1}\" target=\"_blank\">{2}</a></h4><pre>{4}</pre><pre class=\"New\">{5}</pre></div><hr />", oMod.TabId, oMod.ModuleId, oMod.Title, sPortal, oMod.Text, sNewText));
 
                                 iReplaced += 1;
                                 break;
@@ -203,7 +203,7 @@ namespace FortyFingers.DnnMassManipulate.Services
                                     // Update
                                     if (ModuleSqlReplaceSave(GetConnectionString(model), sUpdateSql))
                                     {
-                                        sOut.AppendLine(string.Format("<div><a href=\"/Default.aspx?Tabid={0}&articleType=ArticleView&articleId={1}\" target=\"_blank\">{2}</a></div>", oMod.TabId, oMod.ContentId, oMod.Title));
+                                        sOut.AppendLine(string.Format("<div><a href=\"/Default.aspx?Tabid={0}#{1}\" target=\"_blank\">{2}</a></div>", oMod.TabId, oMod.ModuleId, oMod.Title));
 
                                         iReplaced += 1;
                                     }


### PR DESCRIPTION
The Link to the page shown when doing a list or test replace was incorrect